### PR TITLE
fix can't find module `tokenize`

### DIFF
--- a/readme.markdown
+++ b/readme.markdown
@@ -7,7 +7,7 @@
 # example
 
 ``` js
-var tokenize = require('tokenize')
+var tokenize = require('c-tokenizer')
 var t = tokenize(function (src, token) {
   console.log(token.type + ' => ' + JSON.stringify(src))
 })


### PR DESCRIPTION
If I copy the example code and input and just run them as shown then node can't find the module `tokenize`. I think thats supposed to be `c-tokenizer`.
